### PR TITLE
[feat] swagger API 문서, 주문 수정, 취소 기능 리펙토링

### DIFF
--- a/backend/src/main/java/com/backend/domain/item/item/controller/AdminItemController.java
+++ b/backend/src/main/java/com/backend/domain/item/item/controller/AdminItemController.java
@@ -16,7 +16,7 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/v1/admin/items")
 @RequiredArgsConstructor
-@Tag(name="Item", description = "관리자 상품 컨트롤러")
+@Tag(name="AdminItem", description = "관리자 상품 컨트롤러")
 public class AdminItemController {
 
     private final ItemService itemService;

--- a/backend/src/main/java/com/backend/domain/member/member/controller/MemberController.java
+++ b/backend/src/main/java/com/backend/domain/member/member/controller/MemberController.java
@@ -19,7 +19,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("api/v1/admin")
-@Tag(name="Member", description = "관리자 멤버 컨트롤러")
+@Tag(name="AdminMember", description = "관리자 멤버 컨트롤러")
 public class MemberController {
 
     private final MemberService memberService;

--- a/backend/src/main/java/com/backend/domain/orders/orders/controller/AdminOrderController.java
+++ b/backend/src/main/java/com/backend/domain/orders/orders/controller/AdminOrderController.java
@@ -15,7 +15,7 @@ import java.util.NoSuchElementException;
 @RestController
 @RequestMapping("api/v1/admin/orders")
 @RequiredArgsConstructor
-@Tag(name="Orders", description = "관리자 주문 컨트롤러")
+@Tag(name="AdminOrders", description = "관리자 주문 컨트롤러")
 public class AdminOrderController {
 
     private final OrdersService ordersService;

--- a/backend/src/main/java/com/backend/domain/orders/orders/controller/OrdersController.java
+++ b/backend/src/main/java/com/backend/domain/orders/orders/controller/OrdersController.java
@@ -1,7 +1,6 @@
 package com.backend.domain.orders.orders.controller;
 
 import com.backend.domain.orders.orders.dto.OrdersDto;
-import com.backend.domain.orders.orders.dto.OrdersModifyReqDto;
 import com.backend.domain.orders.orders.entity.Orders;
 import com.backend.domain.orders.orders.service.OrdersService;
 import com.backend.global.rsData.RsData;
@@ -115,9 +114,10 @@ public class OrdersController {
     @Transactional
     public RsData<Void> modifyOrders(
             @PathVariable Long id,
-            @RequestBody OrdersModifyReqDto request
+            @RequestBody OrdersDto.OrdersModifyReqBody request
             ) {
-        Orders orders = ordersService.findById(id).get();
+        Orders orders = ordersService.findById(id)
+                .orElseThrow(() -> new NoSuchElementException("주문을 찾을 수 없습니다. id=" + id));
         ordersService.modifyOrders(orders, request.address());
 
         return new RsData(
@@ -132,7 +132,8 @@ public class OrdersController {
     public RsData<Void> cancelOrders(
             @PathVariable Long id
     ) {
-        Orders orders = ordersService.findById(id).get();
+        Orders orders = ordersService.findById(id)
+                .orElseThrow(() -> new NoSuchElementException("주문을 찾을 수 없습니다. id=" + id));
         orders.setStatus(Orders.Status.CANCELLED);
 
         return new RsData(

--- a/backend/src/main/java/com/backend/domain/orders/orders/dto/OrdersDto.java
+++ b/backend/src/main/java/com/backend/domain/orders/orders/dto/OrdersDto.java
@@ -34,4 +34,8 @@ public class OrdersDto {
             int itemTotalPrice
     ) {}
 
+    public record OrdersModifyReqBody (
+            String address
+    ){}
+
 }

--- a/backend/src/main/java/com/backend/domain/orders/orders/dto/OrdersModifyReqDto.java
+++ b/backend/src/main/java/com/backend/domain/orders/orders/dto/OrdersModifyReqDto.java
@@ -1,5 +1,0 @@
-package com.backend.domain.orders.orders.dto;
-
-public record OrdersModifyReqDto (
-    String address
-){}

--- a/backend/src/main/java/com/backend/domain/orders/orders/entity/Orders.java
+++ b/backend/src/main/java/com/backend/domain/orders/orders/entity/Orders.java
@@ -1,6 +1,5 @@
 package com.backend.domain.orders.orders.entity;
 
-import com.backend.domain.member.member.entity.Member;
 import com.backend.domain.orderitem.orderitem.entity.OrderItem;
 import com.backend.global.jpa.entity.BaseEntity;
 import jakarta.persistence.*;
@@ -31,10 +30,6 @@ public class Orders extends BaseEntity {
     private Status status = Status.ORDERED;
 
     private LocalDateTime deliveryDate;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id", nullable = true)
-    private Member member;
 
     @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<OrderItem> orderItems = new ArrayList<>();

--- a/backend/src/main/java/com/backend/global/springDoc/SpringDoc.java
+++ b/backend/src/main/java/com/backend/global/springDoc/SpringDoc.java
@@ -4,6 +4,8 @@ import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
 import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import org.springdoc.core.models.GroupedOpenApi;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 //swagger 문서를 만들어주는 역할
@@ -16,5 +18,23 @@ import org.springframework.context.annotation.Configuration;
         scheme = "bearer"
 )
 public class SpringDoc {
+
+    // 사용자 관련 API 그룹
+    @Bean
+    public GroupedOpenApi commonApi() {
+        return GroupedOpenApi.builder()
+                .group("일반API") // swagger-ui에서 그룹 이름
+                .pathsToMatch("/api/v1/orders/**","/api/v1/items/**" ) // 이 경로만 포함
+                .build();
+    }
+
+    // 주문 관련 API 그룹
+    @Bean
+    public GroupedOpenApi adminApi() {
+        return GroupedOpenApi.builder()
+                .group("관리자API")
+                .pathsToMatch("/api/v1/admin/**")
+                .build();
+    }
 
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "CloneTest",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
## 📝 작업 개요
- swagger API 문서, 주문 수정, 취소 기능 리펙토링

## 🔍 주요 변경 사항
- swagger 문서 작업 : 일반이랑 관리자 API 그룹으로 분리
- OrdersController에서 수정/취소 API에 fidById 예외처리 추가
- Order 엔터티에서 불필요한 member 필드 빼기
- OrdersModifyReqDto를 OrdersDto에 OrdersModifyReqBody라는 이름으로 통합, 주문 수정 API에 변경사항 적용

## ✅ 체크리스트
- [ ] 코드에 오류가 없음
- [ ] 테스트 코드 작성/수행 완료
- [ ] 문서/주석 최신화
- [ ] 팀 내 코드 스타일 가이드 준수
- [ ] 이슈 연결 여부
      
## 🔗 관련 이슈
- Close #53
